### PR TITLE
Github Actions deploy to Container Registry at Heroku

### DIFF
--- a/.github/workflows/accman-be-deploy-action.yml
+++ b/.github/workflows/accman-be-deploy-action.yml
@@ -1,0 +1,31 @@
+name: Java CI with Maven & Heroku
+
+on:
+  push:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+      - name: Build with Maven
+        run: mvn -B package --file ./finance_manager/pom.xml
+      - name: Copy build to docker folder
+        run: cp ./finance_manager/target/*.jar ./finance_manager/docker/
+      - name: Heroku Docker Container Deploy
+        uses: gonuit/heroku-docker-deploy@v1.3.3
+        with:
+          email: ${{ secrets.HEROKU_EMAIL }}
+          heroku_api_key: ${{ secrets.HEROKU_API_KEY }}
+          heroku_app_name: ${{ secrets.HEROKU_APP_NAME }}
+          dockerfile_directory: ./finance_manager/docker
+          dockerfile_name: Dockerfile_prod
+          docker_options: "--no-cache"
+          process_type: web

--- a/finance_manager/docker/Dockerfile_prod
+++ b/finance_manager/docker/Dockerfile_prod
@@ -1,0 +1,3 @@
+FROM openjdk:17
+ADD *.jar app.jar
+CMD java -Dserver.port=$PORT $JAVA_OPTS -jar app.jar


### PR DESCRIPTION
Overview: Allow automatic maven + docker container builds be deployed to Heroku via Github Actions
* added ./finance_manager/docker/Dockerfile_prod
* added .github/workflow/accman-be-deploy-action.yml
* added Heroku secrets in Github's account Settings/Secrets/Actions